### PR TITLE
fix: use const for truly static final compile time guarantees

### DIFF
--- a/src/me/scana/okgradle/OkGradleDialog.kt
+++ b/src/me/scana/okgradle/OkGradleDialog.kt
@@ -20,7 +20,7 @@ import javax.swing.event.DocumentEvent
 class OkGradleDialog(val interactor: SearchArtifactInteractor) : DialogWrapper(false) {
 
     companion object {
-        private val SEARCH_START_DELAY_IN_MILLIS = 500L
+        const private val SEARCH_START_DELAY_IN_MILLIS = 500L
     }
 
     private val hintLink = LinkLabel<Any>("", null).apply {

--- a/src/me/scana/okgradle/data/GoogleRepository.kt
+++ b/src/me/scana/okgradle/data/GoogleRepository.kt
@@ -47,10 +47,10 @@ class GoogleRepository(val httpClient: HttpClient) : ArtifactRepository {
     }
 
     companion object {
-        val GOOGLE_MAVEN_URL = "https://dl.google.com/dl/android/maven2/"
+        const val GOOGLE_MAVEN_URL = "https://dl.google.com/dl/android/maven2/"
 
-        val MAVEN_METADATA = "maven-metadata.xml"
-        val MAVEN_METADATA_VERSION = "release"
+        const val MAVEN_METADATA = "maven-metadata.xml"
+        const val MAVEN_METADATA_VERSION = "release"
 
         val ARTIFACT_NAMES = listOf(
                 "com.android.support:support-compat",

--- a/src/me/scana/okgradle/data/MavenRepository.kt
+++ b/src/me/scana/okgradle/data/MavenRepository.kt
@@ -10,7 +10,7 @@ import java.net.URLEncoder
 class MavenRepository(private val httpClient: HttpClient, private val gson: Gson) : ArtifactRepository {
 
     companion object {
-        val MAVEN_URL = "http://search.maven.org/solrsearch/select"
+        const val MAVEN_URL = "http://search.maven.org/solrsearch/select"
     }
 
     override fun search(query: String): SearchResult {


### PR DESCRIPTION
Mere `val` in `companion objects` generate getters to access value eg `Companion.getVARIABLE_NAME` however using the `const` keyword enables truly static final compile time guarantees