### PR TITLE
Remove android plugin dependency

### DIFF
--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -7,7 +7,7 @@ apply plugin: 'kotlin'
 
 intellij {
     updateSinceUntilBuild false
-    plugins = ["java", "android", "Groovy", "gradle", "Kotlin"]
+    plugins = ["java", "Groovy", "gradle", "Kotlin"]
     version = "IC-192.7142.36"
 }
 

--- a/plugin/src/main/java/me/scana/okgradle/data/AddDependencyStrategy.kt
+++ b/plugin/src/main/java/me/scana/okgradle/data/AddDependencyStrategy.kt
@@ -1,8 +1,5 @@
 package me.scana.okgradle.data
 
-import com.android.SdkConstants.DOT_GRADLE
-import com.android.SdkConstants.DOT_KTS
-import com.android.tools.idea.gradle.util.GradleUtil
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.PsiManager
@@ -19,6 +16,8 @@ import org.jetbrains.kotlin.psi.KtPsiFactory
 private const val ANNOTATION_PROCESSOR = "annotationProcessor"
 private const val KAPT = "kapt"
 private const val KAPT_PLUGIN = "kotlin-kapt"
+private const val DOT_KTS = ".kts"
+private const val DOT_GRADLE = ".gradle"
 
 interface AddDependencyStrategy {
     fun add(): List<String>

--- a/plugin/src/main/java/me/scana/okgradle/data/AddDependencyUseCase.kt
+++ b/plugin/src/main/java/me/scana/okgradle/data/AddDependencyUseCase.kt
@@ -1,8 +1,5 @@
 package me.scana.okgradle.data
 
-import com.android.SdkConstants
-import me.scana.okgradle.internal.dsl.api.ProjectBuildModel
-import me.scana.okgradle.internal.dsl.api.dependencies.ArtifactDependencySpec
 import com.android.tools.idea.gradle.util.GradleUtil
 import com.intellij.openapi.command.WriteCommandAction
 import com.intellij.openapi.command.impl.DummyProject
@@ -12,12 +9,9 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiManager
-import com.intellij.psi.codeStyle.CodeStyleManager
 import com.intellij.util.ui.TextTransferable
 import me.scana.okgradle.data.repository.Artifact
-import me.scana.okgradle.internal.dsl.api.GradleBuildModel
 import me.scana.okgradle.util.Notifier
-import org.jetbrains.kotlin.psi.KtPsiFactory
 
 object AddDependencyUseCaseFactory {
     fun create(project: Project?, notifier: Notifier): AddDependencyUseCase {
@@ -34,6 +28,8 @@ interface AddDependencyUseCase {
     fun addDependency(module: Module, artifact: Artifact)
     fun copyToClipboard(artifact: Artifact)
 }
+
+private const val FN_BUILD_GRADLE_KTS = "build.gradle.kts"
 
 class AddDependencyUseCaseImpl(
         private val project: Project,
@@ -58,7 +54,7 @@ class AddDependencyUseCaseImpl(
 
     private fun findGradleFile(module: Module): VirtualFile? {
         val buildGradleFile = GradleUtil.getGradleBuildFile(module)
-        return buildGradleFile ?: module.moduleFile?.parent?.findChild(SdkConstants.FN_BUILD_GRADLE_KTS)
+        return buildGradleFile ?: module.moduleFile?.parent?.findChild(FN_BUILD_GRADLE_KTS)
     }
 
     private fun runAddDependencyWriteCommand(psiFile: PsiFile?, command: () -> Unit) {

--- a/plugin/src/main/java/me/scana/okgradle/internal/dsl/api/ProjectBuildModelHandler.kt
+++ b/plugin/src/main/java/me/scana/okgradle/internal/dsl/api/ProjectBuildModelHandler.kt
@@ -15,9 +15,7 @@
  */
 package me.scana.okgradle.internal.dsl.api
 
-import com.android.annotations.VisibleForTesting
 import com.android.tools.idea.gradle.project.sync.GradleFiles
-import com.android.tools.idea.gradle.project.sync.GradleSyncState
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.components.ServiceManager
 import com.intellij.openapi.project.Project
@@ -91,7 +89,6 @@ class ProjectBuildModelHandler(val project: Project) {
   /**
    * DO NOT use outside of tests.
    */
-  @VisibleForTesting
   constructor(project: Project, projectModel: ProjectBuildModel, lastSync: Long = -1L) : this(project) {
     projectBuildModel = projectModel
     modelSyncTime = lastSync

--- a/plugin/src/main/resources/META-INF/plugin.xml
+++ b/plugin/src/main/resources/META-INF/plugin.xml
@@ -56,7 +56,6 @@
     </actions>
 
     <depends>com.intellij.modules.java</depends>
-    <depends>org.jetbrains.android</depends>
     <depends>org.intellij.groovy</depends>
     <depends>org.jetbrains.kotlin</depends>
     <depends>org.jetbrains.plugins.gradle</depends>


### PR DESCRIPTION
Resolves https://github.com/scana/ok-gradle/issues/13

TODO: 
- replace usage of Gradle* classes from android with PsiFile access
or
- embed those classes in plugin's code